### PR TITLE
Project hooks

### DIFF
--- a/bin/bpan
+++ b/bin/bpan
@@ -41,6 +41,7 @@ Project Commands:
   bump          Prepare next version
   publish       Publish the project to $APP index
   register      Register a new $APP package
+  hook          Run a project hook
 
 Information Commands:
   help          Get help for a '$app' command

--- a/lib/hook.bash
+++ b/lib/hook.bash
@@ -1,0 +1,66 @@
+hook:options() (cat <<...
+dryrun    Don't run, just show what would run
+keepgoing Ignore hook failures
+...
+)
+
+hook:main() (
+  git:in-repo ||
+    error "Not in a git repo directory"
+
+  failed=0
+
+  for hook in "$@"; do
+    hook:run "$hook" $option_dryrun $option_keepgoing || {
+      failed=$((failed+1))
+
+      $option_keepgoing || exit 1
+    }
+  done
+
+  [[ $failed = 0 ]] || exit 1
+)
+
+hook:run() (
+  hook=$1
+  dryrun=$2
+  keepgoing=$3
+  failed=0
+
+  while read -r script; do
+    script=${script#*=}
+
+    if $dryrun; then
+      say -y "Running $hook hook: $script (not really, dryrun is enabled)"
+    else
+      say -y "Running $hook hook: $script"
+
+      [[ -x "$script" ]] || {
+        warn "Skipping non-executable $hook hook: $script"
+        continue
+      }
+
+      # TODO - sanitize $script?
+      "./$script" || {
+        code=$?
+        failed=$((failed+1))
+
+        msg="$hook hook $script failed ($code)"
+        if $keepgoing; then
+          warn "$msg"
+        else
+          error "$msg"
+        fi
+      }
+    fi
+
+  done < <(
+    script=".bpan/hooks/$hook"
+    [[ -x "$script" ]] && echo "$script"
+
+    ini:list --file=.bpan/config |
+      grep "^hook\.$hook"
+  )
+
+  return $failed
+)

--- a/lib/publish.bash
+++ b/lib/publish.bash
@@ -20,7 +20,10 @@ publish:main() (
 
   $option_check && return
 
+  source-once hook
+  hook:run pre-publish
   publish:trigger-publish
+  hook:run post-publish
 )
 
 publish:get-env() {


### PR DESCRIPTION
This is a proof-of-concept that I put together because I _thought_ I wanted bpan hooks. But then I pivoted and used something else for my use case. Now I'm not sure if bpan hooks would be useful. If somebody can think of a use case then I might finish it, but for now I consider this throwaway.

Basically it's very similar to git hooks. You can put scripts in `.bpan/hooks/` or define hooks in `.bpan/config`. Only two hooks are actually implemented (incompletely) here: `pre-publish` and `post-publish`.